### PR TITLE
Change downloadSpeed to int

### DIFF
--- a/library/src/main/java/com/github/se_bastiaan/torrentstream/StreamStatus.java
+++ b/library/src/main/java/com/github/se_bastiaan/torrentstream/StreamStatus.java
@@ -20,7 +20,7 @@ public class StreamStatus {
     public final float progress;
     public final int bufferProgress;
     public final int seeds;
-    public final float downloadSpeed;
+    public final int downloadSpeed;
 
     StreamStatus(float progress, int bufferProgress, int seeds, int downloadSpeed) {
         this.progress = progress;


### PR DESCRIPTION
The `downloadSpeed` property stores the speed in bytes per second,
which will always be an integer. Yet, the value was being stored
as a float. This commit fixes this issue.

Fixes #58