### PR TITLE
update version of jlibtorrent to 1.2.14.1

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -41,7 +41,7 @@ android {
 }
 
 ext {
-    libtorrentVersion = '1.2.5.0'
+    libtorrentVersion = '1.2.14.1'
 }
 
 // Custom task which downloads the appropriate version of JAR files for jlibtorrent

--- a/library/src/main/java/com/github/se_bastiaan/torrentstream/Torrent.java
+++ b/library/src/main/java/com/github/se_bastiaan/torrentstream/Torrent.java
@@ -216,7 +216,9 @@ public class Torrent implements AlertListener {
                 }
             }
         }
-
+        if (firstPieceIndexLocal == -1) {
+            firstPieceIndexLocal = 0;
+        }
         if (lastPieceIndexLocal == -1) {
             lastPieceIndexLocal = piecePriorities.length - 1;
         }


### PR DESCRIPTION
- update version of jlibtorrent to 1.2.14.1
- fix error not watching on version 1.2.14.1